### PR TITLE
fix: do not transform existing `require().default`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ After JS file transformation:
 require('foo').default;
 ```
 
-This codemod can be found on [npm](https://www.npmjs.com/package/require-default-codemod).
+> This codemod will not transform existing `require(/* ... */).default`.
+
+See codemod on [npm](https://www.npmjs.com/package/require-default-codemod) or read [blog post](https://remarkablemark.org/blog/2020/06/20/require-default-codemod/).
 
 ## Prerequisites
 

--- a/__testfixtures__/require-default.input.js
+++ b/__testfixtures__/require-default.input.js
@@ -4,12 +4,14 @@ var { bar } = require("./bar");
 
 let baz = require('./baz').baz;
 
+require('./qux').default;
+
 const hello = "world";
 
 1 + 2 === 3;
 
-const qux = require(
-  'qux'
+const quux = require(
+  'quux'
 );
 
-import quux from 'quux';
+import foobar from 'foobar';

--- a/__testfixtures__/require-default.output.js
+++ b/__testfixtures__/require-default.output.js
@@ -4,12 +4,14 @@ var { bar } = require("./bar").default;
 
 let baz = require('./baz').default.baz;
 
+require('./qux').default;
+
 const hello = "world";
 
 1 + 2 === 3;
 
-const qux = require(
-  'qux'
+const quux = require(
+  'quux'
 ).default;
 
-import quux from 'quux';
+import foobar from 'foobar';

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "jscodeshift": "0.10.0"
   },
   "devDependencies": {
-    "@commitlint/cli": "^8.3.5",
-    "@commitlint/config-conventional": "^8.3.4",
-    "eslint": "^7.3.0",
+    "@commitlint/cli": "^9.0.1",
+    "@commitlint/config-conventional": "^9.0.1",
+    "eslint": "^7.3.1",
     "eslint-plugin-prettier": "^3.1.4",
     "husky": "^4.2.5",
-    "jest": "^26.0.1",
+    "jest": "^26.1.0",
     "prettier": "^2.0.5",
     "standard-version": "^8.0.0"
   },

--- a/require-default.js
+++ b/require-default.js
@@ -13,15 +13,24 @@
 module.exports = function (fileInfo, api) {
   var j = api.jscodeshift;
 
-  return j(fileInfo.source)
-    .find(j.CallExpression, {
-      callee: {
-        type: 'Identifier',
-        name: 'require'
-      }
-    })
-    .replaceWith(function (path) {
-      return j.memberExpression(path.value, j.identifier('default'));
-    })
-    .toSource();
+  return (
+    j(fileInfo.source)
+      // find all `require()`
+      .find(j.CallExpression, {
+        callee: {
+          type: 'Identifier',
+          name: 'require'
+        }
+      })
+      // exclude `require()` with `.default`
+      .filter(function (path) {
+        var property = path.parent.node.property;
+        return property ? property.name !== 'default' : true;
+      })
+      // append `.default` to `require()`
+      .replaceWith(function (path) {
+        return j.memberExpression(path.value, j.identifier('default'));
+      })
+      .toSource()
+  );
 };


### PR DESCRIPTION
## What is the motivation for this pull request?

fix: do not transform existing `require().default`

## What is the current behavior?

Existing `require().default` gets `default` property appended.

Input:

```js
require().default;
```

Output:

```js
require().default.default;
```

## What is the new behavior?

`require().default` is filtered and excluded from transformation.

Input:

```js
require().default;
```

Output:

```js
require().default;
```

## Checklist:

- [x] Tests
- [x] Documentation